### PR TITLE
Fix doctl app spec validate

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -1,8 +1,8 @@
-name: docker-phasik.tv
+name: docker-phasik-tv
 services:
 - dockerfile_path: Dockerfile
   github:
     branch: main
     deploy_on_push: true
     repo: lyraphase/docker-phasik.tv
-  name: docker-phasik.tv
+  name: docker-phasik-tv

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -20,4 +20,8 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.11'
+    - name: Install doctl
+      uses: digitalocean/action-doctl@v2
+      with:
+        token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
     - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         python-version: '3.11'
     - name: Install doctl
-      uses: digitalocean/action-doctl@v2
+      uses: trinitronx/action-doctl@add-no-auth-option
       with:
-        token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+        no_auth: 'true'
     - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,4 +42,4 @@ repos:
   rev: v0.0.4
   hooks:
   - id: doctl-app-spec-validate
-    args: [--verbose]
+    args: ['--verbose', '--schema-only']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,3 +38,8 @@ repos:
               vendor/.*|
               tmp/.*
           )$
+- repo: https://github.com/LyraPhase/pre-commit-digitalocean.git
+  rev: v0.0.4
+  hooks:
+  - id: doctl-app-spec-validate
+    args: [--verbose]


### PR DESCRIPTION
Attempt to add GitHub Action + `pre-commit` task to validate DigitalOcean App Spec without need to provide a token (e.g. "offline" mode check):

 - Using: [trinitronx/action-doctl@add-no-auth-option][1]
 - [LyraPhase/pre-commit-digitalocean][2]: to run `doctl app spec validate --schema-only`

[1]: https://github.com/trinitronx/action-doctl/tree/add-no-auth-option
[2]: https://github.com/LyraPhase/pre-commit-digitalocean