### PR TITLE
Fix doctl app spec validate (pre-release testing)

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -1,8 +1,8 @@
-name: docker-phasik.tv
+name: docker-phasik-tv
 services:
 - dockerfile_path: Dockerfile
   github:
     branch: main
     deploy_on_push: true
     repo: lyraphase/docker-phasik.tv
-  name: docker-phasik.tv
+  name: docker-phasik-tv

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -20,4 +20,8 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.11'
+    - name: Install doctl
+      uses: digitalocean/action-doctl@v2
+      with:
+        token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
     - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         python-version: '3.11'
     - name: Install doctl
-      uses: trinitronx/action-doctl@add-no-auth-option
+      uses: trinitronx/action-doctl@add-no-auth-option-pre-release-fork
       with:
         no_auth: 'true'
     - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         python-version: '3.11'
     - name: Install doctl
-      uses: digitalocean/action-doctl@v2
+      uses: trinitronx/action-doctl@add-no-auth-option
       with:
-        token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+        no_auth: 'true'
     - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,4 +42,4 @@ repos:
   rev: v0.0.4
   hooks:
   - id: doctl-app-spec-validate
-    args: [--verbose]
+    args: ['--verbose', '--schema-only']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,3 +38,8 @@ repos:
               vendor/.*|
               tmp/.*
           )$
+- repo: https://github.com/LyraPhase/pre-commit-digitalocean.git
+  rev: v0.0.4
+  hooks:
+  - id: doctl-app-spec-validate
+    args: [--verbose]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
               tmp/.*
           )$
 - repo: https://github.com/LyraPhase/pre-commit-digitalocean.git
-  rev: v0.0.4
+  rev: v0.1.0
   hooks:
-  - id: doctl-app-spec-validate
-    args: ['--verbose', '--schema-only']
+  - id: doctl-app-spec-validate-offline
+    args: ['--verbose']


### PR DESCRIPTION
Testing CI + `pre-commit` hook: `doctl-app-spec-validate-offline`

Using:
- [trinitronx/action-doctl@add-no-auth-option-pre-release-fork][1]
- [LyraPhase/pre-commit-digitalocean@v0.1.0][2]
- [trinitronx/doctl@v1.101.0-pre.git.69cd972159a0][3]

[1]: https://github.com/trinitronx/action-doctl/compare/v2...trinitronx:action-doctl:add-no-auth-option-pre-release-fork?expand=1
[2]: https://github.com/LyraPhase/pre-commit-digitalocean/releases/tag/v0.1.0
[3]: https://github.com/trinitronx/doctl/releases/tag/v1.101.0-pre.git.69cd972159a0