### PR TITLE
 pre-commit: Bump doctl-app-spec-validate-offline hook to v0.1.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
               tmp/.*
           )$
 - repo: https://github.com/LyraPhase/pre-commit-digitalocean.git
-  rev: v0.1.0
+  rev: v0.1.1
   hooks:
   - id: doctl-app-spec-validate-offline
     args: ['--verbose']


### PR DESCRIPTION
Testing pre-release `doctl` with offline `--schema-only` flag.